### PR TITLE
í° fix: 회원가입 시 created_at 필드 NULL로 저장되는 버그 수정

### DIFF
--- a/src/main/java/com/hackplay/hackplay/domain/Member.java
+++ b/src/main/java/com/hackplay/hackplay/domain/Member.java
@@ -64,8 +64,7 @@ public class Member {
 
     @Builder
     public Member(Long id, String uuid , String email, String nickname,  String password, boolean isEmailVerified, String refreshToken, 
-                CommonEnums.Role role, CommonEnums.Status status, LocalDateTime lastLoginAt, String profileImageUrl,
-                LocalDateTime createdAt, LocalDateTime updatedAt ) {
+                CommonEnums.Role role, CommonEnums.Status status, LocalDateTime lastLoginAt, String profileImageUrl) {
         this.id = id;
         this.uuid = uuid;
         this.email = email;
@@ -77,8 +76,8 @@ public class Member {
         this.status = status;
         this.lastLoginAt = lastLoginAt;
         this.profileImageUrl = profileImageUrl;
-        this.createdAt = createdAt;
-        this.updatedAt = updatedAt;
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
     }
 
     // 로그인 시 회원 리프레쉬 토큰 DB 저장 및 마지막 로그인 시점 저장.


### PR DESCRIPTION
회원가입 요청 처리 중 member 엔티티의 created_at 값이 자동으로 저장되지 않아 PostgreSQL의 NOT NULL 제약 조건을 위반하는 문제를 수정했습니다.

- Member 엔티티에 생성 시점 저장 추가
- 생성 시점 자동 저장 로직 검증
- 회원가입 성공 시 정상 응답(200) 반환 확인