### PR TITLE
🐛 fix: 이메일 인증 시 Member 조회 오류 수정 및 인증 플로우 개선

### DIFF
--- a/src/main/java/com/hackplay/hackplay/common/BaseResponseStatus.java
+++ b/src/main/java/com/hackplay/hackplay/common/BaseResponseStatus.java
@@ -20,6 +20,7 @@ public enum BaseResponseStatus {
 
     // ===================== Email ERROR =====================
     FAIL_MAIL_SEND(HttpStatus.FORBIDDEN, "메일 전송에 실패했습니다."),
+    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "이메일 인증이 완료되지 않았습니다."),
 
     // ===================== Directory ERROR =====================
     ROOT_DIRECTORY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "루트 디렉토리는 이미 존재합니다."),

--- a/src/main/java/com/hackplay/hackplay/domain/Member.java
+++ b/src/main/java/com/hackplay/hackplay/domain/Member.java
@@ -85,8 +85,4 @@ public class Member {
         this.refreshToken = refreshToken;
         this.lastLoginAt = LocalDateTime.now();
     }
-
-    public void verifyEmailAuth(){
-        this.isEmailVerified = true;
-    }
 }

--- a/src/main/java/com/hackplay/hackplay/service/EmailServiceImpl.java
+++ b/src/main/java/com/hackplay/hackplay/service/EmailServiceImpl.java
@@ -16,7 +16,6 @@ import org.thymeleaf.templateresolver.ClassLoaderTemplateResolver;
 import com.hackplay.hackplay.common.BaseException;
 import com.hackplay.hackplay.common.BaseResponseStatus;
 import com.hackplay.hackplay.config.redis.RedisUtil;
-import com.hackplay.hackplay.domain.Member;
 import com.hackplay.hackplay.dto.EmailAuthReqDto;
 import com.hackplay.hackplay.dto.EmailVerifyReqDto;
 import com.hackplay.hackplay.repository.MemberRepository;
@@ -55,11 +54,6 @@ public class EmailServiceImpl implements EmailService{
 
     @Override
     public String setEmail(String email, String code) {
-        Member member = memberRepository.findByEmail(email);
-        if (member == null) {
-            throw new BaseException(BaseResponseStatus.NO_EXIST_MEMBERS);
-        }
-
         Context context = new Context();
         context.setVariable("code", code);
         ClassLoaderTemplateResolver templateResolver = new ClassLoaderTemplateResolver();
@@ -125,13 +119,7 @@ public class EmailServiceImpl implements EmailService{
         if (!findCodeByEmail.equals(emailVerifyReqDto.getVerifyCode())) {
             throw new BaseException(BaseResponseStatus.INVALID_VERIFICATION_CODE);
         }
-
-        Member member = memberRepository.findByEmail(emailVerifyReqDto.getEmail());
-        if (member == null) {
-            throw new BaseException(BaseResponseStatus.NO_EXIST_MEMBERS);
-        }
-
-        member.verifyEmailAuth();
+        redisUtil.setDataExpire(emailVerifyReqDto.getEmail() + ":verified", "true", 300L);
     }
 
     @Override


### PR DESCRIPTION
- 이메일 인증 과정에서 Member가 존재하지 않아도 인증 가능하도록 로직 수정
- verifyEmail()에서 Member 조회 로직 제거
- 이메일 인증 성공 시 Redis에 verified 플래그(email:verified) 저장하도록 변경
- 회원가입 시 Redis의 인증 여부를 확인하여 이메일 인증 필수화