### PR TITLE
feat: JWT 기반 로그아웃 API 구현 및 Refresh Token 폐기 로직 추가

### DIFF
--- a/src/main/java/com/hackplay/hackplay/config/SecurityConfig.java
+++ b/src/main/java/com/hackplay/hackplay/config/SecurityConfig.java
@@ -48,7 +48,8 @@ public class SecurityConfig {
             .formLogin(fl -> fl.disable())
             .authorizeHttpRequests(authz -> authz
                     .requestMatchers(
-            "/api/v1/auth/**",
+            "/api/v1/auth/signin",
+                        "/api/v1/auth/signup",
                         "/api/v1/email/**",
                         "/v3/api-docs/**",
                         "/swagger-ui/**",

--- a/src/main/java/com/hackplay/hackplay/controller/AuthController.java
+++ b/src/main/java/com/hackplay/hackplay/controller/AuthController.java
@@ -31,4 +31,10 @@ public class AuthController {
     public ApiResponse<SigninRespDto> signin(@Valid @RequestBody SigninReqDto signinReqDto){
         return ApiResponse.success(authService.signin(signinReqDto));
     }
+
+    @PostMapping("/signout")
+    public ApiResponse<Void> signout(){
+        authService.signout();
+        return ApiResponse.success();
+    }
 }

--- a/src/main/java/com/hackplay/hackplay/domain/Member.java
+++ b/src/main/java/com/hackplay/hackplay/domain/Member.java
@@ -92,4 +92,8 @@ public class Member {
         this.refreshToken = refreshToken;
         this.lastLoginAt = LocalDateTime.now();
     }
+
+    public void signoutUpdate() {
+        this.refreshToken = null;
+    }
 }

--- a/src/main/java/com/hackplay/hackplay/service/AuthService.java
+++ b/src/main/java/com/hackplay/hackplay/service/AuthService.java
@@ -7,4 +7,5 @@ import com.hackplay.hackplay.dto.SignupReqDto;
 public interface AuthService {
     void signup(SignupReqDto signupReqDto);
     SigninRespDto signin(SigninReqDto signinReqDto);
+    void signout();
 }

--- a/src/main/java/com/hackplay/hackplay/service/AuthServiceImpl.java
+++ b/src/main/java/com/hackplay/hackplay/service/AuthServiceImpl.java
@@ -2,6 +2,8 @@ package com.hackplay.hackplay.service;
 
 import java.util.UUID;
 
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,7 +78,20 @@ public class AuthServiceImpl implements AuthService{
         member.signinUpdate(refreshToken);
 
         SigninRespDto signinRespDto = SigninRespDto.entityToDto(member, accessToken, refreshToken);
-
+    
         return signinRespDto;
+    }
+
+    @Override
+    @Transactional
+    public void signout() {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String uuid = (String) authentication.getPrincipal();
+
+        Member member =  memberRepository.findByUuid(uuid)
+                .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_MEMBERS));
+
+        member.signoutUpdate();
     }
 }

--- a/src/main/java/com/hackplay/hackplay/service/ProjectServiceImpl.java
+++ b/src/main/java/com/hackplay/hackplay/service/ProjectServiceImpl.java
@@ -17,7 +17,6 @@ import com.hackplay.hackplay.common.BaseResponseStatus;
 import com.hackplay.hackplay.domain.Member;
 import com.hackplay.hackplay.domain.MemberProgress;
 import com.hackplay.hackplay.domain.Project;
-import com.hackplay.hackplay.domain.Submission;
 import com.hackplay.hackplay.dto.ProjectCreateReqDto;
 import com.hackplay.hackplay.dto.ProjectRespDto;
 import com.hackplay.hackplay.dto.ProjectUpdateReqDto;


### PR DESCRIPTION
JWT 기반 인증 구조에서 로그아웃 시 서버가 토큰을 즉시 만료시킬 수 없기 때문에,
사용자가 로그아웃을 요청할 경우 서버 측에서 Refresh Token을 폐기하여
재사용을 방지하고 보안성을 강화하는 기능을 구현함.

- 로그아웃 요청 시 Access Token 기반 사용자 식별 후 Refresh Token 폐기 처리
- 유효한 Refresh Token은 DB에서 제거, 만료되었거나 존재하지 않아도 성공 응답 반환
- JWT 인증 필터 및 SecurityConfig 수정으로 signout 요청 시 정상적으로 인증 과정 수행되도록 개선
- Member 엔티티 및 AuthService 구현부에서 signout 처리 로직 추가