### PR TITLE
✨ feat: Lecture 진행도 조회 API 및 Lecture enum 숫자 저장 및 프로젝트·진행도 구조 개선

### DIFF
--- a/src/main/java/com/hackplay/hackplay/common/BaseResponseStatus.java
+++ b/src/main/java/com/hackplay/hackplay/common/BaseResponseStatus.java
@@ -41,6 +41,7 @@ public enum BaseResponseStatus {
     PROJECT_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "프로젝트 생성에 실패했습니다."),
     PROJECT_DELETION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "프로젝트 삭제에 실패했습니다."),
     PROJECT_START_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "프로젝트 실행에 실패했습니다."),
+    PROJECT_ALREADY_EXISTS_FOR_LECTURE(HttpStatus.CONFLICT, "이미 해당 강의에 대한 프로젝트가 존재합니다."),
     
     // ===================== Template ERROR =====================
     TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "템플릿을 찾을 수 없습니다."),

--- a/src/main/java/com/hackplay/hackplay/common/CommonEnums.java
+++ b/src/main/java/com/hackplay/hackplay/common/CommonEnums.java
@@ -1,5 +1,7 @@
 package com.hackplay.hackplay.common;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
 public class CommonEnums {
     public enum Role {
         PLAN("기획"),
@@ -67,22 +69,29 @@ public class CommonEnums {
 
     public enum Lecture {
         PROJECT(
+            1,
             "실전 프로젝트 해보기",
             4,
             Role.FRONT,
             Level.INTERMEDIATE
         );
 
-        private final String title;       // 강의명
-        private final int totalWeek;      // 전체 주차 수
-        private final Role role;          // 담당 역할(Front/Back/Full/공통 등)
-        private final Level level;        // 난이도(초급/중급/고급)
+        private final int id;
+        private final String title;
+        private final int totalWeek;
+        private final Role role;
+        private final Level level;
 
-        Lecture(String title, int totalWeek, Role role, Level level) {
+        Lecture(int id, String title, int totalWeek, Role role, Level level) {
+            this.id = id;
             this.title = title;
             this.totalWeek = totalWeek;
             this.role = role;
             this.level = level;
+        }
+
+        public int getId() {
+            return id;
         }
 
         public String getTitle() {
@@ -100,6 +109,20 @@ public class CommonEnums {
         public Level getLevel() {
             return level;
         }
+
+        @JsonCreator
+        public static Lecture fromJson(int id) {
+            return fromId(id);
+        }
+
+        public static Lecture fromId(int id) {
+            for (Lecture lecture : values()) {
+                if (lecture.id == id) {
+                    return lecture;
+                }
+            }
+            throw new IllegalArgumentException("Invalid lecture id: " + id);
+        }
     }
 
     public enum Level {
@@ -107,4 +130,11 @@ public class CommonEnums {
         INTERMEDIATE,
         ADVANCED
     }
+
+    public enum WeekProgressStatus {
+        COMPLETED,
+        IN_PROGRESS,
+        NOT_STARTED
+    }
+
 }

--- a/src/main/java/com/hackplay/hackplay/common/LectureAttributeConverter.java
+++ b/src/main/java/com/hackplay/hackplay/common/LectureAttributeConverter.java
@@ -1,0 +1,20 @@
+package com.hackplay.hackplay.common;
+
+import com.hackplay.hackplay.common.CommonEnums.Lecture;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class LectureAttributeConverter
+        implements AttributeConverter<Lecture, Short> {
+
+    @Override
+    public Short convertToDatabaseColumn(Lecture lecture) {
+        return lecture == null ? null : (short) lecture.getId();
+    }
+
+    @Override
+    public Lecture convertToEntityAttribute(Short dbData) {
+        return dbData == null ? null : Lecture.fromId(dbData);
+    }
+}

--- a/src/main/java/com/hackplay/hackplay/controller/ProjectController.java
+++ b/src/main/java/com/hackplay/hackplay/controller/ProjectController.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.hackplay.hackplay.common.ApiResponse;
+import com.hackplay.hackplay.common.CommonEnums.Lecture;
+import com.hackplay.hackplay.dto.LectureProgressRespDto;
 import com.hackplay.hackplay.dto.ProjectCreateReqDto;
 import com.hackplay.hackplay.dto.ProjectRespDto;
 import com.hackplay.hackplay.dto.ProjectUpdateReqDto;
@@ -32,6 +34,12 @@ public class ProjectController {
     public ApiResponse<Void> createProject(@Valid @RequestBody ProjectCreateReqDto projectCreateReqDto) throws IOException, InterruptedException {
         projectService.create(projectCreateReqDto);
         return ApiResponse.success();
+    }
+
+    @GetMapping("/lectures/{lectureId}/progress")
+    public ApiResponse<LectureProgressRespDto> getLectureProgress(@PathVariable("lectureId") int lectureId) {
+        Lecture lecture = Lecture.fromId(lectureId);
+        return ApiResponse.success(projectService.getLectureProgress(lecture));
     }
 
     @GetMapping

--- a/src/main/java/com/hackplay/hackplay/domain/Project.java
+++ b/src/main/java/com/hackplay/hackplay/domain/Project.java
@@ -4,8 +4,10 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 
 import com.hackplay.hackplay.common.CommonEnums;
+import com.hackplay.hackplay.common.LectureAttributeConverter;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -14,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,7 +24,12 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "project")
+@Table(
+    name = "project",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "lecture"})
+    }
+)
 @NoArgsConstructor(access =  AccessLevel.PROTECTED)
 public class Project {
     
@@ -39,7 +47,7 @@ public class Project {
     @Column(name = "description", length = 500)
     private String description;
 
-    @Column(name = "lecture", length = 500)
+    @Column(name = "lecture", nullable = false)
     private CommonEnums.Lecture lecture;
 
     @Column(name = "template_type", nullable = false, length = 50)

--- a/src/main/java/com/hackplay/hackplay/dto/LectureProgressRespDto.java
+++ b/src/main/java/com/hackplay/hackplay/dto/LectureProgressRespDto.java
@@ -1,0 +1,12 @@
+package com.hackplay.hackplay.dto;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LectureProgressRespDto {
+    private List<LectureWeekProgressDto> weeks;
+}

--- a/src/main/java/com/hackplay/hackplay/dto/LectureWeekProgressDto.java
+++ b/src/main/java/com/hackplay/hackplay/dto/LectureWeekProgressDto.java
@@ -1,0 +1,14 @@
+package com.hackplay.hackplay.dto;
+
+import com.hackplay.hackplay.common.CommonEnums.WeekProgressStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LectureWeekProgressDto {
+    private int week;
+    private WeekProgressStatus status;
+    private Long projectId;
+}

--- a/src/main/java/com/hackplay/hackplay/dto/ProjectRespDto.java
+++ b/src/main/java/com/hackplay/hackplay/dto/ProjectRespDto.java
@@ -1,5 +1,6 @@
 package com.hackplay.hackplay.dto;
 
+import com.hackplay.hackplay.common.CommonEnums;
 import com.hackplay.hackplay.domain.Project;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +13,7 @@ public class ProjectRespDto {
     private Long id;
     private String name;
     private String description;
+    private CommonEnums.Lecture lecture;
     private String templateType;
     private Boolean isPublic;
     private String nickname;
@@ -24,6 +26,7 @@ public class ProjectRespDto {
                 .id(project.getId())
                 .name(project.getName())
                 .description(project.getDescription())
+                .lecture(project.getLecture())
                 .templateType(project.getTemplateType())
                 .isPublic(project.getIsPublic())
                 .nickname(project.getMember().getNickname())

--- a/src/main/java/com/hackplay/hackplay/repository/MemberProgressRepository.java
+++ b/src/main/java/com/hackplay/hackplay/repository/MemberProgressRepository.java
@@ -11,6 +11,6 @@ import com.hackplay.hackplay.domain.Project;
 
 @Repository
 public interface MemberProgressRepository  extends JpaRepository<MemberProgress, Long>{
-
+    void deleteByProject(Project project);
     Optional<MemberProgress> findByMemberAndProject(Member member, Project project);
 }

--- a/src/main/java/com/hackplay/hackplay/repository/ProjectRepository.java
+++ b/src/main/java/com/hackplay/hackplay/repository/ProjectRepository.java
@@ -1,13 +1,21 @@
 package com.hackplay.hackplay.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.hackplay.hackplay.common.CommonEnums.Lecture;
+import com.hackplay.hackplay.domain.Member;
 import com.hackplay.hackplay.domain.Project;
 
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long>{
 
     boolean existsByNameAndMemberId(String name, Long id);
+
+    Optional<Project> findByMemberAndLecture(Member member, Lecture lecture);
+
+    boolean existsByMemberAndLecture(Member member, Lecture lecture);
     
 }

--- a/src/main/java/com/hackplay/hackplay/service/AuthServiceImpl.java
+++ b/src/main/java/com/hackplay/hackplay/service/AuthServiceImpl.java
@@ -21,7 +21,6 @@ import com.hackplay.hackplay.dto.SigninResultRespDto;
 import com.hackplay.hackplay.dto.SignupReqDto;
 import com.hackplay.hackplay.repository.MemberRepository;
 
-import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 
 @Service

--- a/src/main/java/com/hackplay/hackplay/service/ProjectService.java
+++ b/src/main/java/com/hackplay/hackplay/service/ProjectService.java
@@ -3,12 +3,15 @@ package com.hackplay.hackplay.service;
 import java.io.IOException;
 import java.util.List;
 
+import com.hackplay.hackplay.common.CommonEnums;
+import com.hackplay.hackplay.dto.LectureProgressRespDto;
 import com.hackplay.hackplay.dto.ProjectCreateReqDto;
 import com.hackplay.hackplay.dto.ProjectRespDto;
 import com.hackplay.hackplay.dto.ProjectUpdateReqDto;
 
 public interface ProjectService {
     void create(ProjectCreateReqDto request) throws IOException, InterruptedException;
+    LectureProgressRespDto getLectureProgress(CommonEnums.Lecture lecture);
     List<ProjectRespDto> getProjects();
     ProjectRespDto getProject(Long projectId);
     void update(Long projectId, ProjectUpdateReqDto request);

--- a/src/main/java/com/hackplay/hackplay/service/ProjectServiceImpl.java
+++ b/src/main/java/com/hackplay/hackplay/service/ProjectServiceImpl.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
@@ -18,9 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.hackplay.hackplay.common.BaseException;
 import com.hackplay.hackplay.common.BaseResponseStatus;
+import com.hackplay.hackplay.common.CommonEnums;
+import com.hackplay.hackplay.common.CommonEnums.WeekProgressStatus;
 import com.hackplay.hackplay.domain.Member;
 import com.hackplay.hackplay.domain.MemberProgress;
 import com.hackplay.hackplay.domain.Project;
+import com.hackplay.hackplay.dto.LectureProgressRespDto;
+import com.hackplay.hackplay.dto.LectureWeekProgressDto;
 import com.hackplay.hackplay.dto.ProjectCreateReqDto;
 import com.hackplay.hackplay.dto.ProjectRespDto;
 import com.hackplay.hackplay.dto.ProjectUpdateReqDto;
@@ -52,103 +57,27 @@ public class ProjectServiceImpl implements ProjectService {
     public void create(ProjectCreateReqDto projectCreateReqDto)
             throws IOException, InterruptedException {
 
+        // ===============================
+        // 인증 사용자
+        // ===============================
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         String memberUuid = (String) authentication.getPrincipal();
 
         Member member = memberRepository.findByUuid(memberUuid)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_MEMBERS));
 
+        // ===============================
+        // 강의별 프로젝트 1개 제한
+        // ===============================
+        if (projectRepository.existsByMemberAndLecture(member, projectCreateReqDto.getLecture())) {
+            throw new BaseException(BaseResponseStatus.PROJECT_ALREADY_EXISTS_FOR_LECTURE);
+        }
+
+        // ===============================
+        // Project 생성
+        // ===============================
         UUID projectUuid = UUID.randomUUID();
 
-        // 호스트 경로 (파일 존재 확인 및 DB 저장용)
-        Path projectPath = Paths
-                .get(projectsBasePath, projectUuid.toString())
-                .toAbsolutePath();
-
-        // 컨테이너 내부 경로 사용
-        String containerScriptPath = "/scripts/create-" + projectCreateReqDto.getTemplateType() + ".sh";
-        String containerProjectPath = "/projects/" + projectUuid.toString();
-
-        // 호스트에서 스크립트 파일 존재 확인 (선택사항)
-        String hostScriptPath = Paths.get(
-                scriptsBasePath,
-                "create-" + projectCreateReqDto.getTemplateType() + ".sh"
-        ).toAbsolutePath().toString();
-
-        if (!Files.exists(Paths.get(hostScriptPath))) {
-            throw new BaseException(BaseResponseStatus.SCRIPT_NOT_FOUND);
-        }
-
-        // Docker 명령어 실행을 위한 ProcessBuilder 설정 (컨테이너 내부 경로 사용)
-        ProcessBuilder pb = new ProcessBuilder(
-                "/usr/bin/docker", "exec",
-                "-i",
-                "-w", "/",
-                "hackplay-generator",
-                "/bin/bash",
-                containerScriptPath,
-                containerProjectPath,
-                projectCreateReqDto.getName()
-        );
-
-        // 환경 변수 설정
-        Map<String, String> env = pb.environment();
-        env.put("DOCKER_HOST", "unix:///var/run/docker.sock");
-        env.put("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin");
-
-        pb.redirectErrorStream(true);
-
-        log.info("Starting project creation for: {}", projectCreateReqDto.getName());
-        log.info("Project UUID: {}", projectUuid);
-        log.info("Host project path: {}", projectPath);
-        log.info("Host script path: {}", hostScriptPath);
-        log.info("Container script path: {}", containerScriptPath);
-        log.info("Container project path: {}", containerProjectPath);
-        log.info("Command: {}", String.join(" ", pb.command()));
-
-        Process process = pb.start();
-
-        // 프로세스 출력 로깅
-        StringBuilder output = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(process.getInputStream()))) {
-
-            String line;
-            while ((line = reader.readLine()) != null) {
-                log.info("[GENERATOR] {}", line);
-                output.append(line).append("\n");
-            }
-        }
-
-        int exitCode = process.waitFor();
-        log.info("Process exit code: {}", exitCode);
-
-        if (exitCode != 0) {
-            log.error("Project creation script failed with exit code: {}", exitCode);
-            log.error("Script output: {}", output.toString());
-            throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
-        }
-
-        // 프로젝트 폴더가 실제로 생성되었는지 확인
-        if (!Files.exists(projectPath)) {
-            log.error("Project directory was not created: {}", projectPath);
-            throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
-        }
-
-        // 프로젝트 폴더에 기본 파일들이 있는지 확인 (추가 검증)
-        try {
-            long fileCount = Files.list(projectPath).count();
-            if (fileCount == 0) {
-                log.error("Project directory is empty: {}", projectPath);
-                throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
-            }
-            log.info("Project created successfully with {} files/directories", fileCount);
-        } catch (IOException e) {
-            log.error("Error checking project directory contents: {}", e.getMessage());
-            throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
-        }
-
-        // 데이터베이스에 프로젝트 저장
         Project project = Project.builder()
                 .uuid(projectUuid)
                 .name(projectCreateReqDto.getName())
@@ -168,8 +97,322 @@ public class ProjectServiceImpl implements ProjectService {
                         .build()
         );
 
-        log.info("Project created and saved to database successfully: {}", projectCreateReqDto.getName());
+        // ===============================
+        // 경로 설정
+        // ===============================
+        Path projectPath = Paths.get(projectsBasePath, projectUuid.toString()).toAbsolutePath();
+        Path scriptPath = Paths.get(
+                scriptsBasePath,
+                "create-" + projectCreateReqDto.getTemplateType() + ".sh"
+        ).toAbsolutePath();
+
+        if (!Files.exists(scriptPath)) {
+            throw new BaseException(BaseResponseStatus.SCRIPT_NOT_FOUND);
+        }
+
+        log.info("Project UUID: {}", projectUuid);
+        log.info("Project Path: {}", projectPath);
+        log.info("Script Path: {}", scriptPath);
+
+        // ===============================
+        // ProcessBuilder 생성
+        // ===============================
+        ProcessBuilder pb = buildProcess(
+                scriptPath,
+                projectPath,
+                project.getName(),
+                projectCreateReqDto.getTemplateType()
+        );
+
+        pb.redirectErrorStream(true);
+        log.info("Command: {}", String.join(" ", pb.command()));
+
+        // ===============================
+        // 실행
+        // ===============================
+        Process process = pb.start();
+
+        StringBuilder output = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(process.getInputStream()))) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                log.info("[GENERATOR] {}", line);
+                output.append(line).append("\n");
+            }
+        }
+
+        int exitCode = process.waitFor();
+        log.info("Script exit code: {}", exitCode);
+
+        if (exitCode != 0) {
+            log.error("Project creation failed\n{}", output);
+            throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
+        }
+
+        // ===============================
+        // 생성 검증
+        // ===============================
+        if (!Files.exists(projectPath) || Files.list(projectPath).findAny().isEmpty()) {
+            throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
+        }
+
+        log.info("Project created successfully");
     }
+
+    private ProcessBuilder buildProcess(
+            Path scriptPath,
+            Path projectPath,
+            String projectName,
+            String templateType
+    ) {
+        return isWindows()
+                ? buildWindowsProcess(scriptPath, projectPath, projectName)
+                : buildLinuxProcess(projectPath, projectName, templateType);
+    }
+
+    private ProcessBuilder buildWindowsProcess(
+            Path scriptPath,
+            Path projectPath,
+            String projectName
+    ) {
+        String bashExe = "C:/Program Files/Git/bin/bash.exe";
+
+        return new ProcessBuilder(
+                bashExe,
+                toBashPath(scriptPath),
+                toBashPath(projectPath),
+                projectName
+        );
+    }
+
+    private ProcessBuilder buildLinuxProcess(
+            Path projectPath,
+            String projectName,
+            String templateType
+    ) {
+        ProcessBuilder pb = new ProcessBuilder(
+                "/usr/bin/docker", "exec",
+                "-i",
+                "-w", "/",
+                "hackplay-generator",
+                "/bin/bash",
+                "/scripts/create-" + templateType + ".sh",
+                "/projects/" + projectPath.getFileName(),
+                projectName
+        );
+
+        Map<String, String> env = pb.environment();
+        env.put("DOCKER_HOST", "unix:///var/run/docker.sock");
+        env.put("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin");
+
+        return pb;
+    }
+
+    private boolean isWindows() {
+        return System.getProperty("os.name").toLowerCase().contains("win");
+    }
+
+    private String toBashPath(Path path) {
+        return path.toAbsolutePath()
+                .toString()
+                .replace("\\", "/")
+                .replaceFirst("^([A-Za-z]):", "/$1")
+                .toLowerCase();
+    }
+
+    // public void create(ProjectCreateReqDto projectCreateReqDto)
+    //         throws IOException, InterruptedException {
+
+    //     Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    //     String memberUuid = (String) authentication.getPrincipal();
+
+    //     Member member = memberRepository.findByUuid(memberUuid)
+    //             .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_MEMBERS));
+
+    //     if (projectRepository.existsByMemberAndLecture(member, projectCreateReqDto.getLecture())) {
+    //         throw new BaseException(BaseResponseStatus.PROJECT_ALREADY_EXISTS_FOR_LECTURE);
+    //     }
+
+    //     UUID projectUuid = UUID.randomUUID();
+
+    //     // 호스트 경로 (파일 존재 확인 및 DB 저장용)
+    //     Path projectPath = Paths
+    //             .get(projectsBasePath, projectUuid.toString())
+    //             .toAbsolutePath();
+
+    //     // 컨테이너 내부 경로 사용
+    //     String containerScriptPath = "/scripts/create-" + projectCreateReqDto.getTemplateType() + ".sh";
+    //     String containerProjectPath = "/projects/" + projectUuid.toString();
+
+    //     // 호스트에서 스크립트 파일 존재 확인
+    //     String hostScriptPath = Paths.get(
+    //             scriptsBasePath,
+    //             "create-" + projectCreateReqDto.getTemplateType() + ".sh"
+    //     ).toAbsolutePath().toString();
+
+    //     if (!Files.exists(Paths.get(hostScriptPath))) {
+    //         throw new BaseException(BaseResponseStatus.SCRIPT_NOT_FOUND);
+    //     }
+
+    //     // Docker 명령어 실행을 위한 ProcessBuilder 설정 (컨테이너 내부 경로 사용)
+    //     ProcessBuilder pb = new ProcessBuilder(
+    //             "/usr/bin/docker", "exec",
+    //             "-i",
+    //             "-w", "/",
+    //             "hackplay-generator",
+    //             "/bin/bash",
+    //             containerScriptPath,
+    //             containerProjectPath,
+    //             projectCreateReqDto.getName()
+    //     );
+
+    //     // 환경 변수 설정
+    //     Map<String, String> env = pb.environment();
+    //     env.put("DOCKER_HOST", "unix:///var/run/docker.sock");
+    //     env.put("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin");
+
+    //     pb.redirectErrorStream(true);
+
+    //     log.info("Starting project creation for: {}", projectCreateReqDto.getName());
+    //     log.info("Project UUID: {}", projectUuid);
+    //     log.info("Host project path: {}", projectPath);
+    //     log.info("Host script path: {}", hostScriptPath);
+    //     log.info("Container script path: {}", containerScriptPath);
+    //     log.info("Container project path: {}", containerProjectPath);
+    //     log.info("Command: {}", String.join(" ", pb.command()));
+
+    //     Process process = pb.start();
+
+    //     // 프로세스 출력 로깅
+    //     StringBuilder output = new StringBuilder();
+    //     try (BufferedReader reader = new BufferedReader(
+    //             new InputStreamReader(process.getInputStream()))) {
+
+    //         String line;
+    //         while ((line = reader.readLine()) != null) {
+    //             log.info("[GENERATOR] {}", line);
+    //             output.append(line).append("\n");
+    //         }
+    //     }
+
+    //     int exitCode = process.waitFor();
+    //     log.info("Process exit code: {}", exitCode);
+
+    //     if (exitCode != 0) {
+    //         log.error("Project creation script failed with exit code: {}", exitCode);
+    //         log.error("Script output: {}", output.toString());
+    //         throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
+    //     }
+
+    //     // 프로젝트 폴더가 실제로 생성되었는지 확인
+    //     if (!Files.exists(projectPath)) {
+    //         log.error("Project directory was not created: {}", projectPath);
+    //         throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
+    //     }
+
+    //     // 프로젝트 폴더에 기본 파일들이 있는지 확인 (추가 검증)
+    //     try {
+    //         long fileCount = Files.list(projectPath).count();
+    //         if (fileCount == 0) {
+    //             log.error("Project directory is empty: {}", projectPath);
+    //             throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
+    //         }
+    //         log.info("Project created successfully with {} files/directories", fileCount);
+    //     } catch (IOException e) {
+    //         log.error("Error checking project directory contents: {}", e.getMessage());
+    //         throw new BaseException(BaseResponseStatus.PROJECT_CREATION_FAILED);
+    //     }
+
+    //     // 데이터베이스에 프로젝트 저장
+    //     Project project = Project.builder()
+    //             .uuid(projectUuid)
+    //             .name(projectCreateReqDto.getName())
+    //             .description(projectCreateReqDto.getDescription())
+    //             .templateType(projectCreateReqDto.getTemplateType())
+    //             .isPublic(projectCreateReqDto.getIsPublic())
+    //             .lecture(projectCreateReqDto.getLecture())
+    //             .member(member)
+    //             .build();
+
+    //     projectRepository.save(project);
+
+    //     memberProgressRepository.save(
+    //             MemberProgress.builder()
+    //                     .member(member)
+    //                     .project(project)
+    //                     .build()
+    //     );
+
+    //     log.info("Project created and saved to database successfully: {}", projectCreateReqDto.getName());
+    // }
+
+    @Override
+    public LectureProgressRespDto getLectureProgress(CommonEnums.Lecture lecture) {
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        String uuid = (String) auth.getPrincipal();
+
+        Member member = memberRepository.findByUuid(uuid)
+            .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_EXIST_MEMBERS));
+
+        Project project = projectRepository
+            .findByMemberAndLecture(member, lecture)
+            .orElse(null);
+
+        // 프로젝트가 아직 없으면 → 전부 NOT_STARTED
+        if (project == null) {
+            List<LectureWeekProgressDto> weeks =
+                IntStream.rangeClosed(1, lecture.getTotalWeek())
+                    .mapToObj(w -> new LectureWeekProgressDto(
+                        w,
+                        WeekProgressStatus.NOT_STARTED,
+                        null
+                    ))
+                    .toList();
+
+            return new LectureProgressRespDto(weeks);
+        }
+
+        MemberProgress progress = memberProgressRepository
+            .findByMemberAndProject(member, project)
+            .orElseThrow(() -> new BaseException(BaseResponseStatus.NO_PROGRESS));
+
+        int currentWeek = progress.getCurrentWeek();
+        boolean isCompleted = progress.isCompleted();
+
+        List<LectureWeekProgressDto> weeks =
+            IntStream.rangeClosed(1, project.getTotalWeek())
+                .mapToObj(week -> {
+
+                    if (isCompleted || week < currentWeek) {
+                        return new LectureWeekProgressDto(
+                            week,
+                            WeekProgressStatus.COMPLETED,
+                            project.getId()
+                        );
+                    }
+
+                    if (week == currentWeek) {
+                        return new LectureWeekProgressDto(
+                            week,
+                            WeekProgressStatus.IN_PROGRESS,
+                            project.getId()
+                        );
+                    }
+
+                    return new LectureWeekProgressDto(
+                        week,
+                        WeekProgressStatus.NOT_STARTED,
+                        null
+                    );
+                })
+                .toList();
+
+        return new LectureProgressRespDto(weeks);
+    }
+
 
     @Override
     public List<ProjectRespDto> getProjects() {
@@ -229,6 +472,8 @@ public class ProjectServiceImpl implements ProjectService {
     public void delete(Long projectId) {
         Project project = projectRepository.findById(projectId)
                 .orElseThrow(() -> new BaseException(BaseResponseStatus.PROJECT_NOT_FOUND));
+
+        memberProgressRepository.deleteByProject(project);
 
         Path projectPath = Paths.get(projectsBasePath, project.getUuid().toString());
         if (Files.exists(projectPath)) {


### PR DESCRIPTION
Lecture enum을 DB에 SMALLINT 값으로 저장하도록 AttributeConverter를 도입하고, Project 생성·조회 흐름에 lecture 기반 메타데이터(totalWeek 등)를 반영했다. 또한 강의/주차 진행 상태 API를 위한 DTO와 Repository 구조를 정비했다.

- Lecture enum id 기반 매핑 및 Converter 추가
- Project entity에 lecture/totalWeek 연계 반영
- 프로젝트·강의 진행도 조회용 DTO 추가
- 관련 서비스, 컨트롤러, 레포지토리 로직 정합성 수정