### PR TITLE
feat: Swagger 에러 응답 코드 문서화

### DIFF
--- a/src/main/java/com/hackplay/hackplay/config/SwaggerConfig.java
+++ b/src/main/java/com/hackplay/hackplay/config/SwaggerConfig.java
@@ -1,9 +1,13 @@
 package com.hackplay.hackplay.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -13,14 +17,29 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI apiInfo() {
         return new OpenAPI()
-            .info(new Info().title("My API").version("v1.0"))
+            .info(new Info().title("HackPlay API").version("v1.0"))
             .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
-            .components(new io.swagger.v3.oas.models.Components()
+            .components(new Components()
                 .addSecuritySchemes("BearerAuth",
                     new SecurityScheme()
                         .name("Authorization")
                         .type(SecurityScheme.Type.HTTP)
                         .scheme("bearer")
                         .bearerFormat("JWT")));
+    }
+
+    @Bean
+    public OperationCustomizer globalErrorResponses() {
+        return (operation, handlerMethod) -> {
+            ApiResponses responses = operation.getResponses();
+            if (responses == null) {
+                responses = new ApiResponses();
+                operation.setResponses(responses);
+            }
+            responses.addApiResponse("401", new ApiResponse().description("인증 토큰이 없거나 만료되었습니다."));
+            responses.addApiResponse("403", new ApiResponse().description("접근 권한이 없습니다."));
+            responses.addApiResponse("500", new ApiResponse().description("서버 내부 오류가 발생했습니다."));
+            return operation;
+        };
     }
 }

--- a/src/main/java/com/hackplay/hackplay/controller/AdminController.java
+++ b/src/main/java/com/hackplay/hackplay/controller/AdminController.java
@@ -2,18 +2,13 @@ package com.hackplay.hackplay.controller;
 
 import java.io.File;
 import java.util.List;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 
 import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.hackplay.hackplay.common.ApiResponse;
 import com.hackplay.hackplay.dto.AdminGradeReqDto;
@@ -21,6 +16,7 @@ import com.hackplay.hackplay.dto.AdminSubmissionDetailRespDto;
 import com.hackplay.hackplay.dto.AdminSubmissionListRespDto;
 import com.hackplay.hackplay.service.AdminService;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -31,36 +27,36 @@ public class AdminController {
 
     private final AdminService adminService;
 
-    // 제출 전체 조회
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping
     public ApiResponse<List<AdminSubmissionListRespDto>> getAllSubmissions() {
         return ApiResponse.success(adminService.getAllSubmissions());
     }
 
-    // 제출 상세 조회
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "제출 내역이 존재하지 않습니다.")
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/{submissionId}")
     public ApiResponse<AdminSubmissionDetailRespDto> getSubmissionDetail(@PathVariable("submissionId") Long submissionId) {
         return ApiResponse.success(adminService.getSubmissionDetail(submissionId));
     }
 
-    // 제출 채점 (PASS / FAIL)
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "제출 내역이 존재하지 않습니다.")
+    })
     @PreAuthorize("hasRole('ADMIN')")
     @PostMapping("/{submissionId}/grade")
     public ApiResponse<String> gradeSubmission(
             @PathVariable("submissionId") Long submissionId,
             @Valid @RequestBody AdminGradeReqDto adminGradeReqDto) {
-
         adminService.grade(submissionId, adminGradeReqDto.getStatus());
         return ApiResponse.success();
     }
 
-    // Zip 다운로드
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "제출 내역이 존재하지 않습니다.")
     @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/submission/{submissionId}/download")
     public ResponseEntity<FileSystemResource> download(@PathVariable("submissionId") Long submissionId) {
-
         FileSystemResource resource = adminService.downloadSubmissionZip(submissionId);
         File file = resource.getFile();
 
@@ -70,5 +66,4 @@ public class AdminController {
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .body(resource);
     }
-
 }

--- a/src/main/java/com/hackplay/hackplay/controller/AuthController.java
+++ b/src/main/java/com/hackplay/hackplay/controller/AuthController.java
@@ -3,20 +3,13 @@ package com.hackplay.hackplay.controller;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.hackplay.hackplay.common.ApiResponse;
-import com.hackplay.hackplay.dto.ReissueRespDto;
-import com.hackplay.hackplay.dto.SigninReqDto;
-import com.hackplay.hackplay.dto.SigninRespDto;
-import com.hackplay.hackplay.dto.SigninResultRespDto;
-import com.hackplay.hackplay.dto.SignupReqDto;
+import com.hackplay.hackplay.dto.*;
 import com.hackplay.hackplay.service.AuthService;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -25,64 +18,45 @@ import lombok.RequiredArgsConstructor;
 @RestController
 @RequestMapping("/api/v1/auth")
 public class AuthController {
-    
+
     private final AuthService authService;
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "이메일 인증이 완료되지 않았습니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 사용 중인 이메일입니다.")
+    })
     @PostMapping("/signup")
     public ApiResponse<Void> signup(@Valid @RequestBody SignupReqDto signupReqDto){
         authService.signup(signupReqDto);
         return ApiResponse.success();
     }
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "이메일 또는 비밀번호가 올바르지 않습니다.")
+    })
     @PostMapping("/signin")
     public ApiResponse<SigninRespDto> signin(@Valid @RequestBody SigninReqDto signinReqDto, HttpServletResponse response){
-        SigninResultRespDto signinResultRespDto = authService.signin(signinReqDto);    
+        SigninResultRespDto signinResultRespDto = authService.signin(signinReqDto);
 
-        ResponseCookie accessCookie = ResponseCookie.from(
-                "accessToken",
-                signinResultRespDto.getAccessToken()
-        )
-            .httpOnly(true)
-            .secure(true)
-            .sameSite("None")
-            .path("/")
-            .maxAge(60 * 60)
-            .build();
-
-        ResponseCookie refreshCookie = ResponseCookie.from(
-                "refreshToken",
-                signinResultRespDto.getRefreshToken()
-        )
-            .httpOnly(true)
-            .secure(true)
-            .sameSite("None")
-            .path("/")
-            .maxAge(60 * 60 * 24 * 7)
-            .build();
+        ResponseCookie accessCookie = ResponseCookie.from("accessToken", signinResultRespDto.getAccessToken())
+            .httpOnly(true).secure(true).sameSite("None").path("/").maxAge(60 * 60).build();
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", signinResultRespDto.getRefreshToken())
+            .httpOnly(true).secure(true).sameSite("None").path("/").maxAge(60 * 60 * 24 * 7).build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
-        
+
         return ApiResponse.success(signinResultRespDto.getSigninRespDto());
     }
 
     @PostMapping("/signout")
     public ApiResponse<Void> signout(@AuthenticationPrincipal String uuid, HttpServletResponse response){
         ResponseCookie deleteAccess = ResponseCookie.from("accessToken", "")
-            .path("/")
-            .httpOnly(true)
-            .secure(true)
-            .sameSite("None")
-            .maxAge(0)
-            .build();
-
+            .path("/").httpOnly(true).secure(true).sameSite("None").maxAge(0).build();
         ResponseCookie deleteRefresh = ResponseCookie.from("refreshToken", "")
-            .path("/")
-            .httpOnly(true)
-            .secure(true)
-            .sameSite("None")
-            .maxAge(0)
-            .build();
+            .path("/").httpOnly(true).secure(true).sameSite("None").maxAge(0).build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, deleteAccess.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, deleteRefresh.toString());
@@ -91,36 +65,21 @@ public class AuthController {
         return ApiResponse.success();
     }
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않거나 만료된 리프레시 토큰입니다.")
+    })
     @PostMapping("/reissue")
     public ApiResponse<Void> reissue(@CookieValue("refreshToken") String refreshToken, HttpServletResponse response) {
         ReissueRespDto reissueRespDto = authService.reissue(refreshToken);
 
-        ResponseCookie accessCookie = ResponseCookie.from(
-                "accessToken",
-                reissueRespDto.getAccessToken()
-        )
-            .httpOnly(true)
-            .secure(true)
-            .sameSite("None")
-            .path("/")
-            .maxAge(60 * 60)
-            .build();
-
-        ResponseCookie refreshCookie = ResponseCookie.from(
-                "refreshToken",
-                reissueRespDto.getRefreshToken()
-        )
-            .httpOnly(true)
-            .secure(true)
-            .sameSite("None")
-            .path("/")
-            .maxAge(60 * 60 * 24 * 7)
-            .build();
+        ResponseCookie accessCookie = ResponseCookie.from("accessToken", reissueRespDto.getAccessToken())
+            .httpOnly(true).secure(true).sameSite("None").path("/").maxAge(60 * 60).build();
+        ResponseCookie refreshCookie = ResponseCookie.from("refreshToken", reissueRespDto.getRefreshToken())
+            .httpOnly(true).secure(true).sameSite("None").path("/").maxAge(60 * 60 * 24 * 7).build();
 
         response.addHeader(HttpHeaders.SET_COOKIE, accessCookie.toString());
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
         return ApiResponse.success();
     }
-
 }

--- a/src/main/java/com/hackplay/hackplay/controller/EmailController.java
+++ b/src/main/java/com/hackplay/hackplay/controller/EmailController.java
@@ -1,15 +1,13 @@
 package com.hackplay.hackplay.controller;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.hackplay.hackplay.common.ApiResponse;
 import com.hackplay.hackplay.dto.EmailAuthReqDto;
 import com.hackplay.hackplay.dto.EmailVerifyReqDto;
 import com.hackplay.hackplay.service.EmailService;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -19,19 +17,31 @@ import lombok.RequiredArgsConstructor;
 public class EmailController {
 
     private final EmailService emailService;
-    
+
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "메일 전송에 실패했습니다.")
+    })
     @PostMapping("/send")
     public ApiResponse<Void> sendAuthEmail(@Valid @RequestBody EmailAuthReqDto emailAuthReqDto){
         emailService.sendEmail(emailAuthReqDto);
         return ApiResponse.success();
     }
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "인증코드가 일치하지 않습니다.")
+    })
     @PostMapping("/verify")
     public ApiResponse<Void> verifyAuthEmail(@Valid @RequestBody EmailVerifyReqDto emailVerifyReqDto){
         emailService.verifyEmail(emailVerifyReqDto);
         return ApiResponse.success();
     }
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 사용 중인 이메일입니다.")
+    })
     @PostMapping("/check")
     public ApiResponse<String> checkDuplicateEmail(@Valid @RequestBody EmailAuthReqDto emailAuthReqDto){
         return ApiResponse.success(emailService.checkDuplicateEmail(emailAuthReqDto));

--- a/src/main/java/com/hackplay/hackplay/controller/MemberController.java
+++ b/src/main/java/com/hackplay/hackplay/controller/MemberController.java
@@ -3,12 +3,7 @@ package com.hackplay.hackplay.controller;
 import java.io.IOException;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.hackplay.hackplay.common.ApiResponse;
@@ -16,6 +11,7 @@ import com.hackplay.hackplay.dto.MemberReqDto;
 import com.hackplay.hackplay.dto.MemberProfileRespDto;
 import com.hackplay.hackplay.service.MemberService;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -24,21 +20,23 @@ import lombok.RequiredArgsConstructor;
 public class MemberController {
 
     private final MemberService memberService;
-    
-    // 현재 사용자 정보 조회
+
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "존재하지 않는 회원입니다.")
     @GetMapping
     public ApiResponse<MemberProfileRespDto> getMemberInfo(@AuthenticationPrincipal String uuid) {
         return ApiResponse.success(memberService.getMemberInfo(uuid));
     }
 
-    // 현재 사용자 정보 수정
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "존재하지 않는 회원입니다.")
     @PostMapping
     public ApiResponse<MemberProfileRespDto> updateMemberInfo(@AuthenticationPrincipal String uuid, MemberReqDto memberReqDto) {
         memberService.updateMemberInfo(uuid, memberReqDto);
         return ApiResponse.success();
     }
 
-    // 프로필 이미지 업로드
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효하지 않은 파일 형식이거나 크기를 초과했습니다.")
+    })
     @PostMapping("/profile-image")
     public ApiResponse<Void> uploadProfileImage(
             @RequestParam("file") MultipartFile file,
@@ -47,11 +45,10 @@ public class MemberController {
         return ApiResponse.success();
     }
 
-    // 회원 탈퇴
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "존재하지 않는 회원입니다.")
     @DeleteMapping
     public ApiResponse<MemberProfileRespDto> deleteMemberInfo(@AuthenticationPrincipal String uuid) {
         memberService.deleteMemberInfo(uuid);
         return ApiResponse.success();
     }
-
 }

--- a/src/main/java/com/hackplay/hackplay/controller/NodeController.java
+++ b/src/main/java/com/hackplay/hackplay/controller/NodeController.java
@@ -4,6 +4,8 @@ import com.hackplay.hackplay.common.ApiResponse;
 import com.hackplay.hackplay.common.enums.project.NodeType;
 import com.hackplay.hackplay.dto.*;
 import com.hackplay.hackplay.service.NodeService;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,6 +20,10 @@ public class NodeController {
 
     private final NodeService nodeService;
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패 또는 이미 존재하는 이름입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없습니다.")
+    })
     @PostMapping
     public ApiResponse<Void> createNode(
             @AuthenticationPrincipal String uuid,
@@ -27,6 +33,9 @@ public class NodeController {
         return ApiResponse.success();
     }
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "파일 또는 프로젝트를 찾을 수 없습니다.")
+    })
     @GetMapping("/file/content")
     public ApiResponse<FileRespDto> getFileContent(
             @PathVariable Long projectId,
@@ -34,6 +43,10 @@ public class NodeController {
         return ApiResponse.success(nodeService.getFileContent(projectId, path));
     }
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "파일 크기가 1MB를 초과했습니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "파일을 찾을 수 없습니다.")
+    })
     @PatchMapping("/file/content")
     public ApiResponse<Void> updateFileContent(
             @PathVariable Long projectId,
@@ -42,12 +55,17 @@ public class NodeController {
         return ApiResponse.success();
     }
 
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "디렉토리를 찾을 수 없습니다.")
     @GetMapping("/dir/tree")
     public ApiResponse<DirectoryTreeRespDto> getDirTree(
             @PathVariable Long projectId) {
         return ApiResponse.success(nodeService.getTree(projectId));
     }
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 파일 또는 디렉토리를 찾을 수 없습니다.")
+    })
     @PatchMapping("/rename")
     public ApiResponse<Void> renameNode(
             @PathVariable Long projectId,
@@ -56,6 +74,10 @@ public class NodeController {
         return ApiResponse.success();
     }
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 파일 또는 디렉토리를 찾을 수 없습니다.")
+    })
     @PatchMapping("/move")
     public ApiResponse<Void> moveNode(
             @PathVariable Long projectId,
@@ -64,6 +86,10 @@ public class NodeController {
         return ApiResponse.success();
     }
 
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "해당 파일 또는 디렉토리를 찾을 수 없습니다.")
+    })
     @DeleteMapping
     public ApiResponse<Void> deleteNode(
             @PathVariable Long projectId,

--- a/src/main/java/com/hackplay/hackplay/controller/ProjectController.java
+++ b/src/main/java/com/hackplay/hackplay/controller/ProjectController.java
@@ -4,14 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.hackplay.hackplay.common.ApiResponse;
 import com.hackplay.hackplay.common.enums.lecture.Lecture;
@@ -21,6 +14,7 @@ import com.hackplay.hackplay.dto.ProjectRespDto;
 import com.hackplay.hackplay.dto.ProjectUpdateReqDto;
 import com.hackplay.hackplay.service.ProjectService;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -31,35 +25,42 @@ public class ProjectController {
 
     private final ProjectService projectService;
 
-    // 프로젝트 생성
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "유효성 검증 실패"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 해당 강의에 대한 프로젝트가 존재합니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "프로젝트 생성에 실패했습니다.")
+    })
     @PostMapping
     public ApiResponse<Void> createProject(@Valid @RequestBody ProjectCreateReqDto projectCreateReqDto, @AuthenticationPrincipal String uuid) throws IOException, InterruptedException {
         projectService.create(uuid, projectCreateReqDto);
         return ApiResponse.success();
     }
 
-    // 강의 진행도 조회
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없습니다.")
     @GetMapping("/lectures/{lectureId}/progress")
     public ApiResponse<LectureProgressRespDto> getLectureProgress(@PathVariable("lectureId") int lectureId, @AuthenticationPrincipal String uuid) {
         Lecture lecture = Lecture.fromId(lectureId);
         return ApiResponse.success(projectService.getLectureProgress(uuid, lecture));
     }
 
-    // 프로젝트 목록 조회
     @GetMapping
     public ApiResponse<List<ProjectRespDto>> getProjects(@AuthenticationPrincipal String uuid) {
-        List<ProjectRespDto> projectRespDto = projectService.getProjects(uuid);
-        return ApiResponse.success(projectRespDto);
+        return ApiResponse.success(projectService.getProjects(uuid));
     }
 
-    // 프로젝트 상세 조회
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 프로젝트에 대한 접근 권한이 없습니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없습니다.")
+    })
     @GetMapping("/{projectId}")
     public ApiResponse<ProjectRespDto> getProject(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal String uuid) {
-        ProjectRespDto projectRespDto = projectService.getProject(uuid, projectId);
-        return ApiResponse.success(projectRespDto);
+        return ApiResponse.success(projectService.getProject(uuid, projectId));
     }
 
-    // 프로젝트 수정
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "해당 프로젝트에 대한 접근 권한이 없습니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없습니다.")
+    })
     @PatchMapping("/{projectId}")
     public ApiResponse<Void> updateProject(
             @PathVariable("projectId") Long projectId,
@@ -68,7 +69,10 @@ public class ProjectController {
         return ApiResponse.success();
     }
 
-    // 프로젝트 삭제
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없습니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "프로젝트 삭제에 실패했습니다.")
+    })
     @DeleteMapping("/{projectId}")
     public ApiResponse<Void> deleteProject(@PathVariable("projectId") Long projectId) {
         projectService.delete(projectId);

--- a/src/main/java/com/hackplay/hackplay/controller/SubmissionController.java
+++ b/src/main/java/com/hackplay/hackplay/controller/SubmissionController.java
@@ -4,12 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.hackplay.hackplay.common.ApiResponse;
 import com.hackplay.hackplay.dto.SubmissionDetailRespDto;
@@ -17,6 +12,7 @@ import com.hackplay.hackplay.dto.SubmissionListRespDto;
 import com.hackplay.hackplay.dto.SubmissionReqDto;
 import com.hackplay.hackplay.service.SubmissionService;
 
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -27,20 +23,22 @@ public class SubmissionController {
 
     private final SubmissionService submissionService;
 
-    // 프로젝트 제출
+    @ApiResponses({
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "현재 제출할 수 없는 상태입니다."),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "프로젝트를 찾을 수 없습니다.")
+    })
     @PostMapping
     public ApiResponse<Void> submitProject(@Valid @RequestBody SubmissionReqDto submissionReqDto, @AuthenticationPrincipal String uuid) throws IOException {
         submissionService.submit(uuid, submissionReqDto);
         return ApiResponse.success();
     }
 
-    // 제출 목록 조회
     @GetMapping
     public ApiResponse<List<SubmissionListRespDto>> getMySubmissions(@AuthenticationPrincipal String uuid) {
         return ApiResponse.success(submissionService.getMySubmissions(uuid));
     }
 
-    // 제출 상세 조회
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "제출 내역이 존재하지 않습니다.")
     @GetMapping("/{projectId}")
     public ApiResponse<SubmissionDetailRespDto> getSubmissionDetail(@PathVariable("projectId") Long projectId, @AuthenticationPrincipal String uuid) {
         return ApiResponse.success(submissionService.getSubmissionDetail(uuid, projectId));


### PR DESCRIPTION
SwaggerConfig에 OperationCustomizer로 전체 엔드포인트에 401, 403, 500 자동 등록 각 컨트롤러 메서드에 @ApiResponse 추가로 400, 404, 409 등 엔드포인트별 에러 명시

- AuthController: signup(400,403,409), signin(400,401), reissue(401)
- EmailController: send(400,403), verify(400,403), check(400,409)
- MemberController: 각 메서드 400, profile-image 400
- ProjectController: create(400,409,500), get/update(403,404), delete(404,500)
- NodeController: 각 메서드 400/404 세분화
- SubmissionController: submit(400,404), detail(404)
- AdminController: detail/grade/download(404), grade(400)

Closes #46